### PR TITLE
Add OpenAI model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A Chrome extension that uses AI to customize the appearance of any web page.
 
 > [!NOTE]
-> Bring Your Own API Key (BYOK): Page Magic uses the Anthropic API to do all the magic. You will need to provide your own API key to get started.
+> Bring Your Own API Key (BYOK): Page Magic supports both Anthropic and OpenAI APIs. You will need to provide your own API key to get started.
 
 ## Screenshots
 
@@ -11,7 +11,7 @@ A Chrome extension that uses AI to customize the appearance of any web page.
 Just tell Page Magic what you want to change and it will do it for you.
 
 ![Settings Panel](screenshots/settings.png)
-Add your Anthropic API key to get started, select the model you want to use, and see your API usage cost.
+Add your preferred API key to get started, select the provider and model you want to use, and see your API usage cost.
 
 ## Installation
 
@@ -25,7 +25,7 @@ You will need node.js installed to build the extension.
 6. Click "Load unpacked" and select the cloned repository
 5. You should see **Page Magic** in the list of extensions
 6. Click "Options" to configure your settings (you can also do this from the popup)
-7. In settings, add your Anthropic API key and select the model you want to use
+7. In settings, add your API key, choose the provider (Anthropic or OpenAI) and select the model you want to use
 8. Click "Save" to save your settings
 
 ## Usage

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,8 @@
     "scripting"
   ],
   "host_permissions": [
-    "https://api.anthropic.com/*"
+    "https://api.anthropic.com/*",
+    "https://api.openai.com/*"
   ],
   "action": {
     "default_popup": "popup.html",

--- a/settings.html
+++ b/settings.html
@@ -9,9 +9,17 @@
   <h1>Page Magic Settings</h1>
   
   <div class="form-group">
-    <label for="api-key">Anthropic API Key:</label>
+    <label for="provider-select">API Provider:</label>
+    <select id="provider-select">
+      <option value="anthropic">Anthropic</option>
+      <option value="openai">OpenAI</option>
+    </select>
+  </div>
+
+  <div class="form-group">
+    <label id="api-key-label" for="api-key">Anthropic API Key:</label>
     <input type="password" id="api-key" placeholder="sk-ant-api03-..." />
-    <div class="help-text">
+    <div class="help-text" id="api-key-help">
       Get your API key from <a href="https://console.anthropic.com/settings/keys" target="_blank">console.anthropic.com/settings/keys</a>
     </div>
   </div>

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,8 +1,11 @@
-import { anthropicService } from './api.js';
+import { getAIService } from './api.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
   const apiKeyInput = document.getElementById('api-key') as HTMLInputElement;
   const modelSelect = document.getElementById('model-select') as HTMLSelectElement;
+  const providerSelect = document.getElementById('provider-select') as HTMLSelectElement;
+  const apiKeyLabel = document.getElementById('api-key-label') as HTMLLabelElement;
+  const apiKeyHelp = document.getElementById('api-key-help') as HTMLDivElement;
   const saveBtn = document.getElementById('save-btn') as HTMLButtonElement;
   const testBtn = document.getElementById('test-btn') as HTMLButtonElement;
   const clearAllBtn = document.getElementById('clear-all-btn') as HTMLButtonElement;
@@ -22,30 +25,55 @@ document.addEventListener('DOMContentLoaded', async () => {
   const customizedSitesList = document.getElementById('customized-sites-list') as HTMLDivElement;
 
   // Load existing settings
-  const result = await chrome.storage.sync.get(['anthropicApiKey', 'selectedModel']);
-  if (result.anthropicApiKey) {
-    apiKeyInput.value = result.anthropicApiKey;
+  const result = await chrome.storage.sync.get(['apiProvider','anthropicApiKey','openaiApiKey','selectedModel']);
+  const provider = result.apiProvider || 'anthropic';
+  providerSelect.value = provider;
+  const apiKey = provider === 'openai' ? result.openaiApiKey : result.anthropicApiKey;
+  if (apiKey) {
+    apiKeyInput.value = apiKey;
   }
+  let currentSettings = { ...result, apiProvider: provider };
+
+  function updateProviderUI() {
+    if (providerSelect.value === 'openai') {
+      apiKeyLabel.textContent = 'OpenAI API Key:';
+      apiKeyInput.placeholder = 'sk-...';
+      apiKeyHelp.innerHTML = 'Get your API key from <a href="https://platform.openai.com/account/api-keys" target="_blank">platform.openai.com/account/api-keys</a>';
+    } else {
+      apiKeyLabel.textContent = 'Anthropic API Key:';
+      apiKeyInput.placeholder = 'sk-ant-api03-...';
+      apiKeyHelp.innerHTML = 'Get your API key from <a href="https://console.anthropic.com/settings/keys" target="_blank">console.anthropic.com/settings/keys</a>';
+    }
+  }
+
+  updateProviderUI();
+
+  providerSelect.addEventListener('change', async () => {
+    await chrome.storage.sync.set({ apiProvider: providerSelect.value });
+    currentSettings.apiProvider = providerSelect.value;
+    updateProviderUI();
+    await loadModels();
+  });
 
   // Load available models
   async function loadModels() {
     try {
-      if (result.anthropicApiKey) {
-        // Initialize service to fetch models
-        await chrome.storage.sync.set({ anthropicApiKey: result.anthropicApiKey });
-        const initialized = await anthropicService.initialize();
-        
-        if (initialized) {
-          const models = await anthropicService.getAvailableModels();
+      const aiService = await getAIService();
+      const initialized = await aiService.initialize();
+
+      if (initialized) {
+        const models = await aiService.getAvailableModels();
           populateModelSelect(models);
-          
+
           // Store model lookup table for usage display
           const modelLookup: Record<string, string> = {};
           models.forEach(model => {
             modelLookup[model.id] = model.display_name;
           });
           await chrome.storage.local.set({ pagemagic_model_lookup: modelLookup });
-          
+          result[keyField] = currentKey;
+          result.apiProvider = providerVal;
+
           // Set selected model
           if (result.selectedModel) {
             modelSelect.value = result.selectedModel;
@@ -54,13 +82,13 @@ document.addEventListener('DOMContentLoaded', async () => {
           }
           modelSelect.disabled = false;
           testBtn.disabled = false;
-        }
-      } else {
-        // No API key set
-        modelSelect.innerHTML = '<option value="">No API Key found</option>';
-        modelSelect.disabled = true;
-        testBtn.disabled = true;
+        return;
       }
+
+      // No API key set
+      modelSelect.innerHTML = '<option value="">No API Key found</option>';
+      modelSelect.disabled = true;
+      testBtn.disabled = true;
     } catch (error) {
       console.warn('Failed to load models:', error);
       modelSelect.innerHTML = '<option value="">Failed to load models</option>';
@@ -94,25 +122,30 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Reload models when API key changes
   apiKeyInput.addEventListener('input', async () => {
     const currentKey = apiKeyInput.value.trim();
-    if (currentKey && currentKey.startsWith('sk-ant-') && currentKey !== result.anthropicApiKey) {
+    const providerVal = providerSelect.value;
+    const keyField = providerVal === 'openai' ? 'openaiApiKey' : 'anthropicApiKey';
+    if (currentKey && currentKey !== result[keyField]) {
       modelSelect.innerHTML = '<option value="">Loading models...</option>';
       modelSelect.disabled = true;
-      
+
       try {
-        await chrome.storage.sync.set({ anthropicApiKey: currentKey });
-        const initialized = await anthropicService.initialize();
-        
+        await chrome.storage.sync.set({ [keyField]: currentKey, apiProvider: providerVal });
+        currentSettings[keyField] = currentKey;
+        currentSettings.apiProvider = providerVal;
+        const aiService = await getAIService();
+        const initialized = await aiService.initialize();
+
         if (initialized) {
-          const models = await anthropicService.getAvailableModels();
+          const models = await aiService.getAvailableModels();
           populateModelSelect(models);
-          
+
           // Store model lookup table
           const modelLookup: Record<string, string> = {};
           models.forEach(model => {
             modelLookup[model.id] = model.display_name;
           });
           await chrome.storage.local.set({ pagemagic_model_lookup: modelLookup });
-          
+
           // Reset to first available model
           if (models.length > 0) {
             modelSelect.value = models[0].id;
@@ -132,8 +165,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Load and display usage information
   async function loadUsageInfo() {
     try {
-      const totalUsage = await anthropicService.getTotalUsage();
-      const dailyUsage = await anthropicService.getDailyUsage();
+      const aiService = await getAIService();
+      const totalUsage = await aiService.getTotalUsage();
+      const dailyUsage = await aiService.getDailyUsage();
       
       dailyUsageCost.textContent = `$${dailyUsage.totalCost.toFixed(4)}`;
       dailyUsageRequests.textContent = `${dailyUsage.requests} requests`;
@@ -483,13 +517,15 @@ document.addEventListener('DOMContentLoaded', async () => {
   saveBtn.addEventListener('click', async () => {
     const apiKey = apiKeyInput.value.trim();
     const selectedModel = modelSelect.value;
-    
+    const providerVal = providerSelect.value;
+    const keyField = providerVal === 'openai' ? 'openaiApiKey' : 'anthropicApiKey';
+
     if (!apiKey) {
       showStatus('Please enter an API key', 'error');
       return;
     }
 
-    if (!apiKey.startsWith('sk-ant-')) {
+    if (providerVal === 'anthropic' && !apiKey.startsWith('sk-ant-')) {
       showStatus('API key should start with sk-ant-', 'error');
       return;
     }
@@ -500,10 +536,17 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     try {
-      await chrome.storage.sync.set({ 
-        anthropicApiKey: apiKey,
-        selectedModel: selectedModel
+      await chrome.storage.sync.set({
+        [keyField]: apiKey,
+        selectedModel: selectedModel,
+        apiProvider: providerVal
       });
+      currentSettings[keyField] = apiKey;
+      currentSettings.selectedModel = selectedModel;
+      currentSettings.apiProvider = providerVal;
+      result[keyField] = apiKey;
+      result.selectedModel = selectedModel;
+      result.apiProvider = providerVal;
       showStatus('Settings saved successfully!', 'success');
     } catch (error) {
       showStatus('Failed to save settings', 'error');
@@ -513,9 +556,16 @@ document.addEventListener('DOMContentLoaded', async () => {
   testBtn.addEventListener('click', async () => {
     const apiKey = apiKeyInput.value.trim();
     const selectedModel = modelSelect.value;
+    const providerVal = providerSelect.value;
+    const keyField = providerVal === 'openai' ? 'openaiApiKey' : 'anthropicApiKey';
     
     if (!apiKey) {
       showStatus('Please enter an API key first', 'error');
+      return;
+    }
+
+    if (providerVal === 'anthropic' && !apiKey.startsWith('sk-ant-')) {
+      showStatus('API key should start with sk-ant-', 'error');
       return;
     }
 
@@ -529,28 +579,31 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     try {
       // Save key and model temporarily for test
-      await chrome.storage.sync.set({ 
-        anthropicApiKey: apiKey,
-        selectedModel: selectedModel
-      });
-      
+      const providerVal = providerSelect.value;
+      const keyField = providerVal === 'openai' ? 'openaiApiKey' : 'anthropicApiKey';
+      await chrome.storage.sync.set({ [keyField]: apiKey, selectedModel: selectedModel, apiProvider: providerVal });
+      currentSettings[keyField] = apiKey;
+      currentSettings.selectedModel = selectedModel;
+      currentSettings.apiProvider = providerVal;
+
       // Initialize service and test
-      const initialized = await anthropicService.initialize();
+      const aiService = await getAIService();
+      const initialized = await aiService.initialize();
       if (!initialized) {
         throw new Error('Failed to initialize service');
       }
 
       // Upload test HTML first
-      const uploadResponse = await anthropicService.uploadHTML('<body><p>Test</p></body>');
-      
+      const uploadResponse = await aiService.uploadHTML('<body><p>Test</p></body>');
+
       // Test CSS generation
-      const response = await anthropicService.generateCSS({
+      const response = await aiService.generateCSS({
         fileId: uploadResponse.fileId,
         prompt: 'make text red'
       });
-      
+
       // Clean up test file
-      await anthropicService.deleteFile(uploadResponse.fileId);
+      await aiService.deleteFile(uploadResponse.fileId);
 
       if (response.css) {
         showStatus('Connection successful!', 'success');


### PR DESCRIPTION
## Summary
- allow choosing Anthropic or OpenAI API
- support OpenAI models and cost tracking
- store API provider and keys in settings
- update popup and settings to use selected provider
- document new provider option
- fix duplicated block in settings.ts

## Testing
- `npm run build` *(fails: vite not found)*
- `npx tsc --noEmit` *(fails: cannot find type definition for chrome)*

------
https://chatgpt.com/codex/tasks/task_e_68540aa6fad0832da817c4c8f1ec9666